### PR TITLE
Remove deprecated fields from footer.html

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,14 +2,14 @@
 <hr />
 
 <div class="previous-post" style="display:inline-block;">
-  {{ if .PrevPage }}
-  <a class="link-reverse" href="{{ .PrevPage.Permalink }}?ref=footer">« {{ .PrevPage.Title | truncate 50 "..."}}</a>
+  {{ if .Prev }}
+  <a class="link-reverse" href="{{ .Prev.Permalink }}?ref=footer">« {{ .Prev.Title | truncate 50 "..."}}</a>
   {{ end }}
 </div>
 
 <div class="next-post", style="display:inline-block;float:right;">
-  {{ if .NextPage }}
-  <a class="link-reverse" href="{{ .NextPage.Permalink }}?ref=footer">{{ .NextPage.Title | truncate 50 "..." }} »</a>
+  {{ if .Next }}
+  <a class="link-reverse" href="{{ .Next.Permalink }}?ref=footer">{{ .Next.Title | truncate 50 "..." }} »</a>
   {{ end }}
 </div>
 


### PR DESCRIPTION
On version Hugo 0.139.3, the theme fails to built. This PR updates the `footer.html` file with updated fields for pagination.

The `NextPage` and `PrevPage` are to be deprecated in the upcoming version 0.140.0 as per this error:

```
ERROR deprecated: .Page.PrevPage was deprecated in Hugo v0.123.0 and will be removed in Hugo 0.140.0. Use .Page.Prev instead.
ERROR deprecated: .Page.NextPage was deprecated in Hugo v0.123.0 and will be removed in Hugo 0.140.0. Use .Page.Next instead.
```
