### PR TITLE
Patch: Updated next and prev references and enhanced printing

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,17 +1,17 @@
 <footer class="page-footer">
 <hr />
-
+  
+{{ if .Prev }}
 <div class="previous-post" style="display:inline-block;">
-  {{ if .PrevPage }}
-  <a class="link-reverse" href="{{ .PrevPage.Permalink }}?ref=footer">« {{ .PrevPage.Title | truncate 50 "..."}}</a>
-  {{ end }}
+  <a class="link-reverse" href="{{ .Prev.Permalink }}?ref=footer">« {{ .Prev.Title | truncate 50 "..."}}</a>
 </div>
+{{ end }}
 
+{{ if .Next }}
 <div class="next-post", style="display:inline-block;float:right;">
-  {{ if .NextPage }}
-  <a class="link-reverse" href="{{ .NextPage.Permalink }}?ref=footer">{{ .NextPage.Title | truncate 50 "..." }} »</a>
-  {{ end }}
+  <a class="link-reverse" href="{{ .Next.Permalink }}?ref=footer">{{ .Next.Title | truncate 50 "..." }} »</a>
 </div>
+{{ end }}
 
 <ul class="page-footer-menu">
   {{/* SOCIALS */}}


### PR DESCRIPTION
Currently, the conditions for `Previous` and `Next Page` use deprecated field references. This patch updates it to adhere to the latest version.

In addition, this patch also moves the conditions out of the div block. That way, the divs will not be printed if there are not `Next` or `Prev` pages.